### PR TITLE
use namespace std inside of the pliib namespace

### DIFF
--- a/pliib.hpp
+++ b/pliib.hpp
@@ -10,9 +10,10 @@
 #include <omp.h>
 #include <functional>
 
+namespace pliib{
+
 using namespace std;
 
-namespace pliib{
     // Char table to test for canonical bases
     static const int valid_dna[127] = {
         1,


### PR DESCRIPTION
This avoids pulling std into every library that includes this header.