### PR TITLE
Fixing integer type for length variables

### DIFF
--- a/pliib.hpp
+++ b/pliib.hpp
@@ -284,7 +284,7 @@ namespace pliib{
     inline void remove_char(char*& s, const std::size_t& len, char r){
         std::size_t write_index = 0;
         std::size_t read_index = 0;
-        for (std::size_t i = 0; i < len, read_index < len; ++i){
+        for (std::size_t i = 0; i < len && read_index < len; ++i){
             if (s[i] != r){
                 s[write_index] = s[read_index];
                 ++write_index;

--- a/pliib.hpp
+++ b/pliib.hpp
@@ -65,9 +65,9 @@ namespace pliib{
     } 
 
     // Check a string (as a char*) for non-canonical DNA bases
-    inline bool canonical(const char* x, int len){
+    inline bool canonical(const char* x, std::size_t len){
         bool trip = false;
-        for (size_t i = 0; i < len; ++i){
+        for (std::size_t i = 0; i < len; ++i){
             trip |= valid_dna[ static_cast<int> (x[i]) ];
         }
         return !trip;
@@ -75,13 +75,13 @@ namespace pliib{
 
     inline bool canonical(std::string seq){
         const char* x = seq.c_str();
-        int len = seq.length();
+        auto len = seq.length();
         return canonical(x, len);
     }
 
 
-    inline void reverse_complement(const char* seq, char*& ret, int len){
-        for (size_t i = len - 1; i >=0; i--){
+    inline void reverse_complement(const char* seq, char*& ret, std::size_t len){
+        for (std::size_t i = len - 1; i >=0; i--){
             ret[ len - 1 - i ] = (char) complement_array[ (int) seq[i] - 65];
         }
     }
@@ -92,8 +92,8 @@ namespace pliib{
 
     /* Capitalize all characters in a string */
     /* Capitalize a C string */
-    inline void to_upper(char* seq, int length){
-        for (size_t i = 0; i < length; i++){
+    inline void to_upper(char* seq, std::size_t length){
+        for (std::size_t i = 0; i < length; i++){
             char c = seq[i];
             seq[i] = ( (c - 91) > 0 ? c - 32 : c);
         }
@@ -101,14 +101,14 @@ namespace pliib{
 
     /* Capitalize a string */
     inline std::string to_upper(std::string& seq){
-        for (size_t i = 0; i < seq.length(); i++){
+        for (std::size_t i = 0; i < seq.length(); i++){
             char c = seq[i];
             seq[i] =  ((c - 91) > 0 ? c - 32 : c);
         }
         return seq;
     }
 
-    inline void countChar(const char* s, char c, int& ret) {
+    inline void countChar(const char* s, char c, std::size_t& ret) {
         ret = 0;
         while(*s++ != '\0') { //Until the end of the string
             if(*s == c) {
@@ -117,14 +117,14 @@ namespace pliib{
         }
     }
 
-    inline void destroy_splits(char**& splits, const int& num_splits, int*& split_sizes){
+    inline void destroy_splits(char**& splits, const std::size_t& num_splits, int*& split_sizes){
         delete [] splits;
         delete [] split_sizes;
     }
 
     // Modified from: https://techoverflow.net/2017/01/23/zero-copy-in-place-string-splitting-in-c/
-    inline void split(char*& s, char delimiter, char**& ret, int& retsize, int*& split_sizes){
-        int num_delim = 0;
+    inline void split(char*& s, char delimiter, char**& ret, std::size_t& retsize, int*& split_sizes){
+        std::size_t num_delim = 0;
         countChar(s, delimiter, num_delim);
 
         ret = new char*[num_delim + 1];
@@ -156,19 +156,19 @@ namespace pliib{
 
     inline void split(std::string s, char delim, std::vector<std::string>& ret){
 
-        int slen = s.length();
+        auto slen = s.length();
         char* s_to_split = new char[slen + 1];
         strncpy(s_to_split, s.c_str(), slen);
         s_to_split[slen] = '\0';
 
         char** splitret;
-        int retsz;
+        std::size_t retsz;
         int* splitsz;
 
         split(s_to_split, delim, splitret, retsz, splitsz);
         ret.resize(retsz);
 
-        for (size_t i = 0; i < retsz; ++i){
+        for (std::size_t i = 0; i < retsz; ++i){
             ret[i].assign(std::string( splitret[i])); 
         }
         destroy_splits(splitret, retsz, splitsz);
@@ -179,14 +179,14 @@ namespace pliib{
     inline std::vector<std::string> split(const std::string s, const char delim){
     
         std::vector<std::string> ret;
-        int slen = s.length();
+        auto slen = s.length();
         char* s_to_split = new char[slen + 1];
 
         strncpy(s_to_split, s.c_str(), slen);
         s_to_split[slen] = '\0';
 
         char** splitret;
-        int retsz;
+        std::size_t retsz;
         int* splitsz;
 
 
@@ -194,7 +194,7 @@ namespace pliib{
 
         ret.resize(retsz);
 
-        for (size_t i = 0; i < retsz; ++i){
+        for (std::size_t i = 0; i < retsz; ++i){
             ret[i].assign(std::string( splitret[i])); 
         }
         destroy_splits(splitret, retsz, splitsz);
@@ -215,7 +215,7 @@ namespace pliib{
     }
     inline std::string join(const std::vector<std::string>& splits, char glue){
         std::stringstream ret;
-        for (size_t i = 0; i < splits.size(); i++){
+        for (std::size_t i = 0; i < splits.size(); i++){
             if (i != 0){
                 ret << glue;
             }
@@ -229,8 +229,8 @@ namespace pliib{
      * first appearance of 'delim'.
      * If delim is the first character, returns an empty string. **/
 
-    inline void trim_after_char(char*&s, const int& len, char delim){
-        int d_index = 0;
+    inline void trim_after_char(char*&s, const std::size_t& len, char delim){
+        std::size_t d_index = 0;
         while(  d_index < len && s[d_index] != delim){
             ++d_index;
         }
@@ -248,16 +248,16 @@ namespace pliib{
      *  Returns a new string with all such occurrences of 'r' removed.
      *  s is destroyed in the process and replaced by a new string.
      *  Works like python's "strip(char)" function. **/
-    inline void strip(char*& s, const int& len, char r){
-        int start = 0;
-        int end = len - 1;
+    inline void strip(char*& s, const std::size_t& len, char r){
+        std::size_t start = 0;
+        std::size_t end = len - 1;
         while (start < len && s[start] == r){
             ++start;
         }
         while(end > 0 && s[end] == r){
             --end;
         }
-        int rsz = end - start + 1;
+        std::size_t rsz = end - start + 1;
         char* ret = new char[rsz + 1];
         memcpy(ret, s + start, rsz * sizeof(char));
         // cerr << ret << endl;
@@ -267,23 +267,23 @@ namespace pliib{
     }
 
     inline void strip(std::string& s, char r){
-        int slen = s.length();
+        auto slen = s.length();
         char* t = new char[slen + 1];
         memcpy(t, s.c_str(), slen);
         strip(t, slen, r);
         s = std::string(t);
     }
 
-    inline void slice(const char* s, size_t start, size_t end, char*& ret){
+    inline void slice(const char* s, std::size_t start, std::size_t end, char*& ret){
        strcopy(s + start, end - start, ret); 
     }
 
 
     /** Removes a character from within a string **/
-    inline void remove_char(char*& s, const int& len, char r){
-        int write_index = 0;
-        int read_index = 0;
-        for (size_t i = 0; i < len, read_index < len; ++i){
+    inline void remove_char(char*& s, const std::size_t& len, char r){
+        std::size_t write_index = 0;
+        std::size_t read_index = 0;
+        for (std::size_t i = 0; i < len, read_index < len; ++i){
             if (s[i] != r){
                 s[write_index] = s[read_index];
                 ++write_index;
@@ -296,9 +296,9 @@ namespace pliib{
     /** Removes any null or whitespace characters from within a string
      *  where whitespace is ' ' or '\t' or '\n'.
      *  Complexity: linear time in |s| **/
-    inline void remove_nulls_and_whitespace(char*& s, const int& len){
-        size_t write_index = 0;
-        for (size_t i = 0; i < len; ++i){
+    inline void remove_nulls_and_whitespace(char*& s, const std::size_t& len){
+        std::size_t write_index = 0;
+        for (std::size_t i = 0; i < len; ++i){
             if (s[i] != '\n' && s[i] != '\t' && s[i] != '\0' && s[i] != ' '){
                 s[write_index] = s[i];
                 ++write_index;
@@ -307,18 +307,18 @@ namespace pliib{
         s[write_index] = '\0';
     }
 
-    inline void paste(const char** splits, const int& numsplits, const int* splitlens, char*& ret){
+    inline void paste(const char** splits, const std::size_t& numsplits, const std::size_t* splitlens, char*& ret){
 
-        int sz = 0;
-        for (size_t i = 0; i < numsplits; ++i){
+        std::size_t sz = 0;
+        for (std::size_t i = 0; i < numsplits; ++i){
             sz += splitlens[i];
         }
         ret = new char[sz + 1];
         ret[sz] = '\0';
 
-        int r_pos = 0;
-        for (size_t i = 0; i < numsplits; ++i){
-            for (size_t j = 0; j < splitlens[i]; ++j){
+        std::size_t r_pos = 0;
+        for (std::size_t i = 0; i < numsplits; ++i){
+            for (std::size_t j = 0; j < splitlens[i]; ++j){
                 ret[r_pos] = splits[i][j];
                 ++r_pos;
             }
@@ -327,7 +327,7 @@ namespace pliib{
 
     inline std::string join(std::vector<std::string> splits, std::string glue){
         std::stringstream ret;
-        for (size_t i = 0; i < splits.size(); i++){
+        for (std::size_t i = 0; i < splits.size(); i++){
             if (i != 0){
                 ret << glue;
             }
@@ -340,7 +340,7 @@ namespace pliib{
     template<typename X>
     inline std::string join(X* x, std::size_t xlen, char glue){
         std::ostringstream ret;
-        for (size_t i = 0; i < xlen; ++i){
+        for (std::size_t i = 0; i < xlen; ++i){
             if (i != 0){
                 ret << glue;
             }
@@ -350,9 +350,9 @@ namespace pliib{
     }
 
     // TODO convert to template
-    inline std::string join(uint64_t* x, int xlen, char glue){
+    inline std::string join(uint64_t* x, std::size_t xlen, char glue){
         std::stringstream ret;
-        for (size_t i = 0; i < xlen; i++){
+        for (std::size_t i = 0; i < xlen; i++){
             if (i != 0){
                 ret << glue;
             }
@@ -410,9 +410,9 @@ namespace pliib{
     template <typename DataType, typename A>
         inline std::vector<DataType, A> p_vv_map(const std::vector<DataType, A> v, typename std::function<DataType(DataType)> lambda){
             std::vector<DataType> results(v.size());
-            size_t sz = v.size();
+            std::size_t sz = v.size();
             #pragma omp parallel for
-            for (size_t i = 0; i < sz; ++i){
+            for (std::size_t i = 0; i < sz; ++i){
                 results[i] = lambda(v[i]);
             }
 
@@ -426,8 +426,8 @@ namespace pliib{
     template<typename DataType, typename A>
         inline std::vector<DataType, A> p_vv_filter(const std::vector<DataType, A>& v, typename std::function<bool(DataType)> lambda){
             std::vector<DataType> results;
-            size_t sz = v.size();
-            for (size_t i = 0; i < sz; ++i){
+            std::size_t sz = v.size();
+            for (std::size_t i = 0; i < sz; ++i){
                 if (lambda(v[i])){
                     results.push_back(v[i]);
                 }
@@ -443,7 +443,7 @@ namespace pliib{
     template<typename DataType, typename A>
         inline void p_vv_apply(std::vector<DataType, A>& v, typename std::function<DataType(DataType)> lambda){
             #pragma omp parallel for //private(i)
-            for (size_t i = 0; i < v.size(); i++){
+            for (std::size_t i = 0; i < v.size(); i++){
                 auto r = lambda(v[i]);
 
                 #pragma omp atomic write

--- a/pliib.hpp
+++ b/pliib.hpp
@@ -110,10 +110,11 @@ namespace pliib{
 
     inline void countChar(const char* s, char c, std::size_t& ret) {
         ret = 0;
-        while(*s++ != '\0') { //Until the end of the string
+        while(*s != '\0') { //Until the end of the string
             if(*s == c) {
                 ++ret;
             }
+            ++s;
         }
     }
 

--- a/test_pliib.cpp
+++ b/test_pliib.cpp
@@ -10,13 +10,14 @@ using namespace pliib;
 
 TEST_CASE("fast split function performs as expected", "[split]"){
 
-    char to_split [25] = "A;StrING;DeLIMITeD:.;by;";
-    to_split[24] = '\0';
+    char* to_split = new char[26];
+    strcpy(to_split, ";A;StrING;DeLIMITeD:.;by;");
+    to_split[25] = '\0';
 
     SECTION("The countChar function works as expected"){
         std::size_t num;
         countChar(to_split, ';', num);
-        REQUIRE(num == 4);
+        REQUIRE(num == 5);
     }
 
     char** ret;
@@ -30,11 +31,13 @@ TEST_CASE("fast split function performs as expected", "[split]"){
     //}
 
 
-    REQUIRE(retsz == 5);
-    REQUIRE(strcmp(ret[0], "A") == 0);
-    REQUIRE(strcmp(ret[1], "StrING") == 0);
-    REQUIRE(split_sizes[2] == 11);
-    REQUIRE(split_sizes[0] == 1);
+    REQUIRE(retsz == 6);
+    REQUIRE(strlen(ret[0]) == 0);
+    REQUIRE(strcmp(ret[1], "A") == 0);
+    REQUIRE(strcmp(ret[2], "StrING") == 0);
+    REQUIRE(split_sizes[3] == 11);
+    REQUIRE(split_sizes[0] == 0);
+    REQUIRE(split_sizes[1] == 1);
 
     SECTION("split works for strings"){
         string s = "ANOTHER:Separated:String";
@@ -44,4 +47,6 @@ TEST_CASE("fast split function performs as expected", "[split]"){
         REQUIRE(ret[0].compare("ANOTHER") == 0);
         REQUIRE(ret[2].compare("String") == 0);
     }
+
+    delete[] to_split;
 }

--- a/test_pliib.cpp
+++ b/test_pliib.cpp
@@ -14,13 +14,13 @@ TEST_CASE("fast split function performs as expected", "[split]"){
     to_split[24] = '\0';
 
     SECTION("The countChar function works as expected"){
-        int num;
+        std::size_t num;
         countChar(to_split, ';', num);
         REQUIRE(num == 4);
     }
 
     char** ret;
-    int retsz;
+    std::size_t retsz;
     int* split_sizes;
     split(to_split, ';', ret, retsz, split_sizes);
 


### PR DESCRIPTION
Fixing the issue explained in my comment on #3.

This PR converts all length- or size-related variables to `std::size` or `auto` if it can be inferred by compiler. In addition, it fixes a minor bug in `countChar` function. The test case is also updated to reflect the changes.