### PR TITLE
Size t ify

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,7 @@ int main(){
     cout << "Copied " << s << " to " << to_split << endl;
     char** ret;
     std::size_t retsz;
-    int* split_sizes;
+    std::size_t* split_sizes;
     split(to_split, ';', ret, retsz, split_sizes);
 
     for (int i = 0; i < retsz; ++i){

--- a/pliib.hpp
+++ b/pliib.hpp
@@ -48,6 +48,19 @@ namespace pliib{
         COMPLEX
     };
 
+    inline bool is_numeric_string(char*& s, std::size_t& len){
+        bool ret = true;
+        for (std::size_t i = 0; i < len; ++i){
+            ret &= (s[i] == 45 || (s[i] <= 57 && s[i] >= 48)); 
+        }
+        return ret;
+    }
+
+    inline bool is_numeric_string(char*& s){
+        std:size_t len = strlen(s);
+        return is_numeric_string(s, len);
+    }
+
     inline void strcopy(const char* src, const std::size_t& len, char*& dest){
        dest = new char[len+1];
        dest[len] = '\0';

--- a/pliib.hpp
+++ b/pliib.hpp
@@ -128,19 +128,19 @@ namespace pliib{
         }
     }
 
-    inline void destroy_splits(char**& splits, const std::size_t& num_splits, int*& split_sizes){
+    inline void destroy_splits(char**& splits, const std::size_t& num_splits, std::size_t*& split_sizes){
         delete [] splits;
         delete [] split_sizes;
     }
 
     // Modified from: https://techoverflow.net/2017/01/23/zero-copy-in-place-string-splitting-in-c/
-    inline void split(char*& s, char delimiter, char**& ret, std::size_t& retsize, int*& split_sizes){
+    inline void split(char*& s, char delimiter, char**& ret, std::size_t& retsize, std::size_t*& split_sizes){
         std::size_t num_delim = 0;
         countChar(s, delimiter, num_delim);
 
         ret = new char*[num_delim + 1];
         retsize = num_delim + 1;
-        split_sizes = new int[num_delim + 1];
+        split_sizes = new std::size_t[num_delim + 1];
 
         ret[0] = s;
 
@@ -174,7 +174,7 @@ namespace pliib{
 
         char** splitret;
         std::size_t retsz;
-        int* splitsz;
+        std::size_t* splitsz;
 
         split(s_to_split, delim, splitret, retsz, splitsz);
         ret.resize(retsz);
@@ -198,7 +198,7 @@ namespace pliib{
 
         char** splitret;
         std::size_t retsz;
-        int* splitsz;
+        std::size_t* splitsz;
 
 
         pliib::split(s_to_split, delim, splitret, retsz, splitsz);

--- a/test_pliib.cpp
+++ b/test_pliib.cpp
@@ -23,7 +23,7 @@ TEST_CASE("fast split function performs as expected", "[split]"){
 
     char** ret;
     std::size_t retsz;
-    int* split_sizes;
+    std::size_t* split_sizes;
     split(to_split, ';', ret, retsz, split_sizes);
 
     //for (int i = 0; i < retsz; ++i){
@@ -70,4 +70,11 @@ TEST_CASE("pliib can fill arrays using its fill_array function", "[fill_array]")
 	REQUIRE(x_long[100] == 10);
 	delete [] x_long;
 
+}
+
+TEST_CASE("is_numeric_string performs as expected.", "[is_numeric_string]"){
+    char* s = "12345";
+    char* t = "12Eg5";
+    REQUIRE(is_numeric_string(s) == true);
+    REQUIRE(is_numeric_string(t) == false);
 }


### PR DESCRIPTION
FINALLY brings size_t (rather than int) to split functions.